### PR TITLE
Incorrect boolean casting

### DIFF
--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -497,7 +497,7 @@ class API
                 return (float) $xml;
             case 'boolean':
             case 'bool':
-                return (boolean) $xml;
+                return (string) $xml === 'true';
             case 'datetime':
                 return new \DateTime((string) $xml);
             default:


### PR DESCRIPTION
`API::normalise` was casting booleans incorrectly.

Casting a string to a bool will always cast to TRUE as it is not a falsy value (even if the text of the string is the word "false")

http://php.net/manual/en/language.types.boolean.php#language.types.boolean.casting

Have changed to explicitly cast to string and check if string is equal to `"true"`
