### PR TITLE
Added check for token NULL value before saving following 401

### DIFF
--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -147,17 +147,20 @@ class API
                     throw new UnauthorizedException;
                 }
 
-                // The token has expired, get a new token
+                // The token may have expired, request a new token
                 $tokenRequest = $this->messageFactory->createRequest('GET', $this->baseUrl . 'branch', self::HOST);
                 $tokenRequest->addHeader('Authorization: Basic ' . base64_encode($this->username.':'.$this->password));
                 $tokenResponse = $this->messageFactory->createResponse();
                 $this->client->send($tokenRequest, $tokenResponse);
 
-                // if we have a token, save it
-                $token = $tokenResponse->getHeader('Token');
-                if ( ! is_null($token)) {
-                    $this->tokenStorage->setToken(trim($token));
+                if (401 === $tokenResponse->getStatusCode()) {   
+                    // Unauthorized: current token hasn't expired or invalid credentials
+                    throw new UnauthorizedException;
                 }
+
+                // save the token
+                $token = $tokenResponse->getHeader('Token');
+                $this->tokenStorage->setToken(trim($token)); 
 
                 // try again
                 return $this->execute($url, true);


### PR DESCRIPTION
If the token header is NULL (as it would be for a 401) and this is saved, the subsequent authorisation attempt is impossible since the existing token has been overwritten.
