### PR TITLE
Updates for feed version 9

### DIFF
--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -74,8 +74,9 @@ class API
      * @param TokenStorageInterface $tokenStorage   The client storage
      * @param ClientInterface       $client         The client
      * @param FactoryInterface      $messageFactory The message factory
+     * @param string                $feedVersion    The feed version
      */
-    public function __construct($dataFeedId, $username, $password, TokenStorageInterface $tokenStorage, ClientInterface $client, FactoryInterface $messageFactory, $feedVersion = 'v8')
+    public function __construct($dataFeedId, $username, $password, TokenStorageInterface $tokenStorage, ClientInterface $client, FactoryInterface $messageFactory, $feedVersion = 'v9')
     {
         $this->baseUrl         = sprintf('/export/%s/'.$feedVersion.'/', $dataFeedId);
         $this->dataFeedId      = $dataFeedId;

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -467,6 +467,7 @@ class API
 
         foreach ($xml->file as $xmlFile) {
             $file = new ChangedFileSummary;
+            $file->setFileId(self::normalise($xmlFile->{'file_id'}, 'int'));
             $file->setFilePropId(self::normalise($xmlFile->{'file_propid'}, 'int'));
             $file->setLastChanged(self::normalise($xmlFile->updated, 'datetime'));
             $file->setIsDeleted(self::normalise($xmlFile->deleted, 'bool'));

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -363,8 +363,8 @@ class API
         $arr = array();
         foreach ($xml->area as $a) {
             $area = new Area(
-                self::normalise($a->min, 'int'),
-                self::normalise($a->max, 'int')
+                self::normalise($a->min, 'float'),
+                self::normalise($a->max, 'float')
             );
             $area->setAttributes($a->attributes());
             $arr[] = $area;

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -366,11 +366,13 @@ class API
         $property->setGroundRent(self::normalise($xml->groundrent, 'string'));
         $property->setCommission(self::normalise($xml->commission, 'string'));
 
-        $landArea = new LandArea(
-            self::normalise($xml->landarea->area, 'float')
-        );
-        $landArea->setAttributes($xml->landarea->attributes());
-        $property->setLandArea($landArea);
+        if ($xml->landarea) {
+            $landArea = new LandArea(
+                self::normalise($xml->landarea->area, 'float')
+            );
+            $landArea->setAttributes($xml->landarea->attributes());
+            $property->setLandArea($landArea);
+        }
 
         $property->setStreetView(
             new StreetView(

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -361,6 +361,7 @@ class API
         $property->setSoldPrice(self::normalise($xml->soldprice, 'int'));
         $property->setGarden(self::normalise($xml->garden, 'boolean'));
         $property->setParking(self::normalise($xml->parking, 'boolean'));
+        $property->setNewBuild(self::normalise($xml->newbuild, 'boolean'));
         $property->setGroundRent(self::normalise($xml->groundrent, 'string'));
         $property->setCommission(self::normalise($xml->commission, 'string'));
 

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -330,6 +330,8 @@ class API
         $price->setAttributes($xml->price->attributes());
         $property->setPrice($price);
 
+        $property->setRentalFees(self::normalise($xml->rentalfees, 'string'));
+        $property->setLettingsFee(self::normalise($xml->lettingsfee, 'string'));
         $property->setRmQualifier(self::normalise($xml->{'rm_qualifier'}, 'int'));
         $property->setAvailable(self::normalise($xml->available, 'string'));
         $property->setUploaded(self::normalise($xml->uploaded, 'string'));

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -44,6 +44,7 @@ use YDD\Vebra\Model\BranchSummary,
     YDD\Vebra\Model\Dimension,
     YDD\Vebra\Model\Bullet,
     YDD\Vebra\Model\File,
+    YDD\Vebra\Model\StreetView,
     YDD\Vebra\Model\ChangedPropertySummary,
     YDD\Vebra\Model\ChangedFileSummary
 ;
@@ -359,6 +360,16 @@ class API
         $property->setParking(self::normalise($xml->parking, 'boolean'));
         $property->setGroundRent(self::normalise($xml->groundrent, 'string'));
         $property->setCommission(self::normalise($xml->commission, 'string'));
+
+        $property->setStreetView(
+            new StreetView(
+                self::normalise($xml->streetview->pov_latitude, 'float'),
+                self::normalise($xml->streetview->pov_longitude, 'float'),
+                self::normalise($xml->streetview->pov_pitch, 'float'),
+                self::normalise($xml->streetview->pov_heading, 'float'),
+                self::normalise($xml->streetview->pov_zoom, 'int')
+            )
+        );
 
         $arr = array();
         foreach ($xml->area as $a) {

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -44,6 +44,7 @@ use YDD\Vebra\Model\BranchSummary,
     YDD\Vebra\Model\Dimension,
     YDD\Vebra\Model\Bullet,
     YDD\Vebra\Model\File,
+    YDD\Vebra\Model\LandArea,
     YDD\Vebra\Model\StreetView,
     YDD\Vebra\Model\ChangedPropertySummary,
     YDD\Vebra\Model\ChangedFileSummary
@@ -360,6 +361,12 @@ class API
         $property->setParking(self::normalise($xml->parking, 'boolean'));
         $property->setGroundRent(self::normalise($xml->groundrent, 'string'));
         $property->setCommission(self::normalise($xml->commission, 'string'));
+
+        $landArea = new LandArea(
+            self::normalise($xml->landarea->area, 'float')
+        );
+        $landArea->setAttributes($xml->landarea->attributes());
+        $property->setLandArea($landArea);
 
         $property->setStreetView(
             new StreetView(

--- a/lib/YDD/Vebra/API.php
+++ b/lib/YDD/Vebra/API.php
@@ -343,7 +343,7 @@ class API
         $property->setRateableValue(self::normalise($xml->{'rateable_value'}, 'string'));
         $property->setType(self::normalise($xml->type, 'string'));
         $property->setFurnished(self::normalise($xml->furnished, 'int'));
-        $property->setRmType(self::normalise($xml->{'rm_type'}, 'string'));
+        $property->setRmType(self::normalise($xml->{'rm_type'}, 'int'));
         $property->setLetBond(self::normalise($xml->{'let_bond'}, 'int'));
         $property->setRmLetTypeId(self::normalise($xml->{'rm_let_type_id'}, 'int'));
         $property->setBedrooms(self::normalise($xml->bedrooms, 'int'));

--- a/lib/YDD/Vebra/Model/Area.php
+++ b/lib/YDD/Vebra/Model/Area.php
@@ -28,8 +28,8 @@ class Area extends AttributedModel
     /**
      * Constructor
      *
-     * @param int $min The minimum
-     * @param int $max The maximum
+     * @param float $min The minimum
+     * @param float $max The maximum
      */
     public function __construct($min, $max)
     {
@@ -42,7 +42,7 @@ class Area extends AttributedModel
     /**
      * get Min
      *
-     * @return int $min
+     * @return float $min
      */
     public function getMin()
     {
@@ -52,13 +52,13 @@ class Area extends AttributedModel
     /**
      * set Min
      *
-     * @param int $min
+     * @param float $min
      *
      * @return object
      */
     public function setMin($min)
     {
-        $this->min = (int) $min;
+        $this->min = (float) $min;
 
         return $this;
     }
@@ -66,7 +66,7 @@ class Area extends AttributedModel
     /**
      * get Max
      *
-     * @return string $max
+     * @return float $max
      */
     public function getMax()
     {
@@ -76,13 +76,13 @@ class Area extends AttributedModel
     /**
      * set Max
      *
-     * @param string $max
+     * @param float $max
      *
      * @return object
      */
     public function setMax($max)
     {
-        $this->max = (int) $max;
+        $this->max = (float) $max;
 
         return $this;
     }

--- a/lib/YDD/Vebra/Model/ChangedFileSummary.php
+++ b/lib/YDD/Vebra/Model/ChangedFileSummary.php
@@ -17,11 +17,36 @@ namespace YDD\Vebra\Model;
  */
 class ChangedFileSummary
 {
+    protected $fileId;
     protected $filePropId;
     protected $lastChanged;
     protected $isDeleted;
     protected $url;
     protected $propUrl;
+
+    /**
+     * set FileId
+     *
+     * @param int $fileId
+     *
+     * @return $this
+     */
+    public function setFileId($fileId)
+    {
+        $this->fileId = (int) $fileId;
+
+        return $this;
+    }
+
+    /**
+     * get FileId
+     *
+     * @return int $fileId
+     */
+    public function getFileId()
+    {
+        return $this->fileId;
+    }
 
     /**
      * set FilePropId

--- a/lib/YDD/Vebra/Model/LandArea.php
+++ b/lib/YDD/Vebra/Model/LandArea.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the YDD\Vebra package.
+ *
+ * (c) 2012 Damon Jones <damon@yummyduckdesign.co.uk> and Matthew Davis <matt@yummyduckdesign.co.uk>
+
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace YDD\Vebra\Model;
+
+/**
+ * LandArea
+ */
+class LandArea extends AttributedModel
+{
+    protected static $attributeTypeMapping = array(
+        'unit'    => 'string'
+    );
+
+    protected $area;
+
+    /**
+     * Constructor
+     *
+     * @param float $area The area
+     */
+    public function __construct($area)
+    {
+        parent::__construct();
+
+        $this->setArea($area);
+    }
+
+    /**
+     * get Area
+     *
+     * @return float $area
+     */
+    public function getArea()
+    {
+        return $this->area;
+    }
+
+    /**
+     * set Area
+     *
+     * @param float $area
+     *
+     * @return object
+     */
+    public function setArea($area)
+    {
+        $this->area = (float) $area;
+
+        return $this;
+    }
+
+}

--- a/lib/YDD/Vebra/Model/Price.php
+++ b/lib/YDD/Vebra/Model/Price.php
@@ -21,7 +21,7 @@ class Price extends AttributedModel
         'rent'      => 'string',
         'currency'  => 'string',
         'qualifier' => 'string',
-        'display'   => 'boolean'
+        'display'   => 'string'
     );
 
     protected $value;

--- a/lib/YDD/Vebra/Model/Property.php
+++ b/lib/YDD/Vebra/Model/Property.php
@@ -62,6 +62,7 @@ class Property extends AttributedModel
     protected $soldPrice;               // int
     protected $garden;                  // boolean
     protected $parking;                 // boolean
+    protected $newBuild;                // boolean
     protected $groundRent;              // varchar 50
     protected $commission;              // varchar 30
     protected $area;                    // Area
@@ -921,6 +922,30 @@ class Property extends AttributedModel
     public function setParking($parking)
     {
         $this->parking = (bool) $parking;
+
+        return $this;
+    }
+
+    /**
+     * get NewBuild
+     *
+     * @return Boolean $newBuild
+     */
+    public function getNewBuild()
+    {
+        return $this->newBuild;
+    }
+
+    /**
+     * set NewBuild
+     *
+     * @param Boolean $newBuild
+     *
+     * @return object
+     */
+    public function setNewBuild($newBuild)
+    {
+        $this->newBuild = (bool) $newBuild;
 
         return $this;
     }

--- a/lib/YDD/Vebra/Model/Property.php
+++ b/lib/YDD/Vebra/Model/Property.php
@@ -63,6 +63,7 @@ class Property extends AttributedModel
     protected $groundRent;              // varchar 50
     protected $commission;              // varchar 30
     protected $area;                    // Area
+    protected $landArea;                // LandArea
     protected $description;             // varchar
     protected $energyEfficiency;        // EnergyRatingPair
     protected $environmentalImpact;     // EnergyRatingPair
@@ -942,6 +943,30 @@ class Property extends AttributedModel
     public function setArea(array $area)
     {
         $this->area = $area;
+
+        return $this;
+    }
+
+    /**
+     * get LandArea
+     *
+     * @return LandArea $landArea
+     */
+    public function getLandArea()
+    {
+        return $this->landArea;
+    }
+
+    /**
+     * set LandArea
+     *
+     * @param LandArea $landArea
+     *
+     * @return object
+     */
+    public function setLandArea(LandArea $landArea)
+    {
+        $this->landArea = $landArea;
 
         return $this;
     }

--- a/lib/YDD/Vebra/Model/Property.php
+++ b/lib/YDD/Vebra/Model/Property.php
@@ -30,6 +30,8 @@ class Property extends AttributedModel
     protected $agentReference;          // varchar 30
     protected $address;                 // Address
     protected $price;                   // Price
+    protected $rentalFees;              // varchar 400
+    protected $lettingsFee;             // varchar 4000
     protected $rmQualifier;             // enum
     protected $available;               // string
     protected $uploaded;                // string
@@ -151,6 +153,54 @@ class Property extends AttributedModel
     public function setPrice(Price $price)
     {
         $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * get RentalFees
+     *
+     * @return string $rentalFees
+     */
+    public function getRentalFees()
+    {
+        return $this->rentalFees;
+    }
+
+    /**
+     * set RentalFees
+     *
+     * @param string $rentalFees
+     *
+     * @return object
+     */
+    public function setRentalFees($rentalFees)
+    {
+        $this->rentalFees = $rentalFees;
+
+        return $this;
+    }
+
+    /**
+     * get LettingsFee
+     *
+     * @return string $lettingsFee
+     */
+    public function getLettingsFee()
+    {
+        return $this->lettingsFee;
+    }
+
+    /**
+     * set LettingsFee
+     *
+     * @param string $lettingsFee
+     *
+     * @return object
+     */
+    public function setLettingsFee($lettingsFee)
+    {
+        $this->lettingsFee = $lettingsFee;
 
         return $this;
     }

--- a/lib/YDD/Vebra/Model/Property.php
+++ b/lib/YDD/Vebra/Model/Property.php
@@ -45,7 +45,7 @@ class Property extends AttributedModel
     protected $rateableValue;           // varchar 30
     protected $type;                    // varchar 50
     protected $furnished;               // enum
-    protected $rmType;                  // varchar 50
+    protected $rmType;                  // int
     protected $letBond;                 // int
     protected $rmLetTypeId;             // enum
     protected $bedrooms;                // int
@@ -516,7 +516,7 @@ class Property extends AttributedModel
     /**
      * get RmType
      *
-     * @return string $rmType
+     * @return int $rmType
      */
     public function getRmType()
     {
@@ -526,13 +526,13 @@ class Property extends AttributedModel
     /**
      * set RmType
      *
-     * @param string $rmType
+     * @param int $rmType
      *
      * @return object
      */
     public function setRmType($rmType)
     {
-        $this->rmType = $rmType;
+        $this->rmType = (int) $rmType;
 
         return $this;
     }

--- a/lib/YDD/Vebra/Model/Property.php
+++ b/lib/YDD/Vebra/Model/Property.php
@@ -37,6 +37,7 @@ class Property extends AttributedModel
     protected $latitude;                // float
     protected $easting;                 // int
     protected $northing;                // int
+    protected $streetView;              // StreetView
     protected $webStatus;               // enum
     protected $customStatus;            // varchar 30
     protected $commRent;                // varchar 30
@@ -317,6 +318,30 @@ class Property extends AttributedModel
     public function setNorthing($northing)
     {
         $this->northing = (int) $northing;
+
+        return $this;
+    }
+
+    /**
+     * get StreetView
+     *
+     * @return StreetView $streetView
+     */
+    public function getStreetView()
+    {
+        return $this->streetView;
+    }
+
+    /**
+     * set StreetView
+     *
+     * @param StreetView $streetView
+     *
+     * @return object
+     */
+    public function setStreetView(StreetView $streetView)
+    {
+        $this->streetView = $streetView;
 
         return $this;
     }

--- a/lib/YDD/Vebra/Model/StreetView.php
+++ b/lib/YDD/Vebra/Model/StreetView.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the YDD\Vebra package.
+ *
+ * (c) 2012 Damon Jones <damon@yummyduckdesign.co.uk> and Matthew Davis <matt@yummyduckdesign.co.uk>
+
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace YDD\Vebra\Model;
+
+/**
+ * StreetView
+ */
+class StreetView
+{
+    protected $povLatitude;
+    protected $povLongitude;
+    protected $povPitch;
+    protected $povHeading;
+    protected $povZoom;
+
+    /**
+     * Constructor
+     *
+     * @param float $povLatitude  The metric value
+     * @param float $povLongitude The imperial value
+     * @param float $povPitch     The mixed value
+     * @param float $povHeading   The mixed value
+     * @param int $povZoom        The pov_zoom value
+     */
+    public function __construct($povLatitude, $povLongitude, $povPitch, $povHeading, $povZoom)
+    {
+        $this->setPovLatitude($povLatitude);
+        $this->setPovLongitude($povLongitude);
+        $this->setPovPitch($povPitch);
+        $this->setPovHeading($povHeading);
+        $this->setPovZoom($povZoom);
+    }
+
+    /**
+     * get PovLatitude
+     *
+     * @return float $povLatitude
+     */
+    public function getPovLatitude()
+    {
+        return $this->povLatitude;
+    }
+
+    /**
+     * set PovLatitude
+     *
+     * @param float $povLatitude
+     *
+     * @return object
+     */
+    public function setPovLatitude($povLatitude)
+    {
+        $this->povLatitude = $povLatitude;
+
+        return $this;
+    }
+
+    /**
+     * get PovLongitude
+     *
+     * @return float $povLongitude
+     */
+    public function getPovLongitude()
+    {
+        return $this->povLongitude;
+    }
+
+    /**
+     * set PovLongitude
+     *
+     * @param float $povLongitude
+     *
+     * @return object
+     */
+    public function setPovLongitude($povLongitude)
+    {
+        $this->povLongitude = $povLongitude;
+
+        return $this;
+    }
+
+    /**
+     * get PovPitch
+     *
+     * @return float $povPitch
+     */
+    public function getPovPitch()
+    {
+        return $this->povPitch;
+    }
+
+    /**
+     * set PovPitch
+     *
+     * @param float $povPitch
+     *
+     * @return object
+     */
+    public function setPovPitch($povPitch)
+    {
+        $this->povPitch = $povPitch;
+
+        return $this;
+    }
+
+    /**
+     * get PovHeading
+     *
+     * @return float $povHeading
+     */
+    public function getPovHeading()
+    {
+        return $this->povHeading;
+    }
+
+    /**
+     * set PovHeading
+     *
+     * @param float $povHeading
+     *
+     * @return object
+     */
+    public function setPovHeading($povHeading)
+    {
+        $this->povHeading = $povHeading;
+
+        return $this;
+    }
+
+    /**
+     * get PovZoom
+     *
+     * @return int $povZoom
+     */
+    public function getPovZoom()
+    {
+        return $this->povZoom;
+    }
+
+    /**
+     * set PovZoom
+     *
+     * @param int $povZoom
+     *
+     * @return object
+     */
+    public function setPovZoom($povZoom)
+    {
+        $this->povZoom = $povZoom;
+
+        return $this;
+    }
+
+}


### PR DESCRIPTION
I've gone over the client feed document changes from version 3 to 8 and introduced the changes that were missed along the way and then added in the new changes for version 9.

The only thing currently missing to my knowledge is the commercial field on the property feed, but as my client doesn't need that right now I don't have the time to add it in.

**Summary of changes**
 - add file_id to changed files summary
 - changed property rm_type from string to int in accordance to the specification
 - change property area min/max fields from type int to float in accordance to the specification
 - add property streetview field
 - add property landarea field
 - add property rentalfees field
 - add property lettingsfee field
 - add property new build field
 - change type of price display attribute from bool to string in accordance to the specification
 - increase default feed version parameter to v9