### PR TITLE
Fix featured always parsed as 1

### DIFF
--- a/lib/YDD/Vebra/Model/AttributedModel.php
+++ b/lib/YDD/Vebra/Model/AttributedModel.php
@@ -56,7 +56,7 @@ class AttributedModel
             switch ($type) {
                 case 'boolean':
                 case 'bool':
-                    $value = (bool) $value;
+                    $value = (bool) strval($value);
                     break;
                 case 'integer':
                 case 'int':


### PR DESCRIPTION
Ref #15 

PHP doesn't seem to cast SimpleXMLElement objects for bool the way it does with other scalars, so get string val first.