### PR TITLE
Patch/buzz version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "*"
+        "kriswallsmith/buzz": "^0.10"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "^0.10"
+        "kriswallsmith/buzz": "^0.16.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The most recent version of `kriswallsmith/buzz` is not compatible with this library, so I've specified the most recent version of Buzz that still remains compatible (according to my testing).